### PR TITLE
Const Correctness

### DIFF
--- a/timerfix.inc
+++ b/timerfix.inc
@@ -75,7 +75,7 @@ native KillPlayerTimers(playerid);
  * <param name="repeating">Whether this timer will repeat or will execute only one time.</param>
  * <returns>The ID of the timer.</returns>
  */
-//native SetTimer(func[], interval, repeating);
+//native SetTimer(const func[], interval, repeating);
 
 /**
  * <summary>Basic SetTimerEx.</summary>
@@ -85,7 +85,7 @@ native KillPlayerTimers(playerid);
  * <param name="format">Special format indicating the types of values the timer will pass.</param>
  * <returns>The ID of the timer.</returns>
  */
-//native SetTimerEx(func[], interval, repeating, const format[], {Float,_}:...);
+//native SetTimerEx(const func[], interval, repeating, const format[], {Float,_}:...);
 
 /**
  * <summary>An improved version of SetTimer.</summary>
@@ -95,7 +95,7 @@ native KillPlayerTimers(playerid);
  * <param name="count">How many times it should repeat before it's killed (-1 for unlimited).</param>
  * <returns>The ID of the timer.</returns>
  */
-native SetTimer_(func[], interval, delay, count);
+native SetTimer_(const func[], interval, delay, count);
 
 /**
  * <summary>An improved version of SetTimerEx.</summary>
@@ -106,7 +106,7 @@ native SetTimer_(func[], interval, delay, count);
  * <param name="format">Special format indicating the types of values the timer will pass.</param>
  * <returns>The ID of the timer.</returns>
  */
-native SetTimerEx_(func[], interval, delay, count, format[], {Float, _}:...);
+native SetTimerEx_(const func[], interval, delay, count,const  format[], {Float, _}:...);
 
 /**
  * <summary>Basic SetPlayerTimer.</summary>
@@ -116,7 +116,7 @@ native SetTimerEx_(func[], interval, delay, count, format[], {Float, _}:...);
  * <param name="repeating">Whether this timer will repeat or will execute only one time.</param>
  * <returns>The ID of the timer.</returns>
  */
-native SetPlayerTimer(playerid, func[], interval, repeating);
+native SetPlayerTimer(playerid,const func[], interval, repeating);
 
 /**
  * <summary>Basic SetPlayerTimerEx.</summary>
@@ -127,7 +127,7 @@ native SetPlayerTimer(playerid, func[], interval, repeating);
  * <param name="format">Special format indicating the types of values the timer will pass.</param>
  * <returns>The ID of the timer.</returns>
  */
-native SetPlayerTimerEx(playerid, func[], interval, repeating, const format[], {Float,_}:...);
+native SetPlayerTimerEx(playerid,const  func[], interval, repeating, const format[], {Float,_}:...);
 
 /**
  * <summary>An improved version of SetPlayerTimer.</summary>
@@ -138,7 +138,7 @@ native SetPlayerTimerEx(playerid, func[], interval, repeating, const format[], {
  * <param name="count">How many times it should repeat before it's killed (-1 for unlimited).</param>
  * <returns>The ID of the timer.</returns>
  */
-native SetPlayerTimer_(playerid, func[], interval, delay, count);
+native SetPlayerTimer_(playerid, const func[], interval, delay, count);
 
 /**
  * <summary>An improved version of SetPlayerTimerEx.</summary>
@@ -150,7 +150,7 @@ native SetPlayerTimer_(playerid, func[], interval, delay, count);
  * <param name="format">Special format indicating the types of values the timer will pass.</param>
  * <returns>The ID of the timer.</returns>
  */
-native SetPlayerTimerEx_(playerid, func[], interval, delay, count, format[], {Float, _}:...);
+native SetPlayerTimerEx_(playerid, const func[], interval, delay, count, const format[], {Float, _}:...);
 
 /**
  * <summary>Gets the name of the function that is called.</summary>
@@ -158,7 +158,7 @@ native SetPlayerTimerEx_(playerid, func[], interval, delay, count, format[], {Fl
  * <param name="func">The name of the function.</param>
  * <param name="maxlength">Maximum length of the returned function name.</param>
  */
-native GetTimerFunctionName(timerid, func[], maxlength = sizeof(func));
+native GetTimerFunctionName(timerid, const func[], maxlength = sizeof(func));
 
 /**
  * <summary>Sets the interval of a timer.</summary>


### PR DESCRIPTION
Fix warning 239: literal array/string passed to a non-const parameter

https://github.com/pawn-lang/compiler/wiki/Const-Correctness